### PR TITLE
Se elimino la dependencia Spring Security por el momento

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-security</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Como se decició en la reunion de 12/07/23, se elimino Spring Security por el momento para no complicar el review a futuro